### PR TITLE
Correct property name for stonefish

### DIFF
--- a/fish/javascript/locations/deep_sea.js
+++ b/fish/javascript/locations/deep_sea.js
@@ -22,7 +22,7 @@ var deep_sea = {
         this.state = new fishing.state([
             resources.fish.whitefish,
             resources.fish.lingcod,
-            resources.fish.rockfish,
+            resources.fish.stonefish,
             resources.fish.marlin,
             resources.fish.mako_shark,
             resources.fish.thresher_shark


### PR DESCRIPTION
`resources.fish` includes `stonefish`, not `rockfish`, so the deep_sea fish list had an undefined element.